### PR TITLE
Added @Output 'change' to trigger change event in Dropdown component.

### DIFF
--- a/components/dropdown/dropdown.ts
+++ b/components/dropdown/dropdown.ts
@@ -1,4 +1,4 @@
-import { Component, Input, forwardRef } from '@angular/core';
+import { Component, Input, Output, EventEmitter, forwardRef } from '@angular/core';
 import { trigger, state, style, transition, animate } from '@angular/animations';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 
@@ -70,6 +70,9 @@ export class DropdownComponent implements ControlValueAccessor {
   @Input()
   public multiple: boolean = false;
 
+  @Output()
+  public change: EventEmitter<any> = new EventEmitter<any>();
+
   get active(): boolean {
     return this._active;
   }
@@ -98,6 +101,7 @@ export class DropdownComponent implements ControlValueAccessor {
 
   writeValue(value: any): void {
     this.selectedItem = value;
+    this.change.emit(value);
     this._onChange(value);
   }
 


### PR DESCRIPTION
I added an `@Output` attribute to the 'Dropdown' component to allow the developer to handle the 'change' event when selecting an item in the dropdown.

In this way the component can be called with:
`<lsu-dropdown [(ngModel)]="selectedItem" [data]="data" (change)="onChange($event)"></lsu-dropdown>`
And the event will be handled with a normal function:
`onChange(value) {
console.log('New value: ' + value);
}`

Needed this in a project but I thought other people can benefit from it.

Cheers,
Stefano